### PR TITLE
Add Podman / podman-compose support

### DIFF
--- a/.changes/unreleased/Added-20260518-194322.yaml
+++ b/.changes/unreleased/Added-20260518-194322.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: 'Podman / podman-compose support: bind mounts now carry the `:Z` SELinux relabel suffix (no-op on Docker) and the README documents pre-pull and user-systemd notes for rootless Podman.'
+body: 'Podman / podman-compose support: bind mounts now carry the `:z` SELinux shared-relabel suffix (and `:ro` for `config.json`), ignored on non-SELinux hosts and honoured by both Docker and Podman on SELinux-enabled hosts. README documents pre-pull and user-systemd notes for rootless Podman.'
 time: 2026-05-18T19:43:22.858932806+10:00

--- a/.changes/unreleased/Added-20260518-194322.yaml
+++ b/.changes/unreleased/Added-20260518-194322.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Podman / podman-compose support: bind mounts now carry the `:Z` SELinux relabel suffix (no-op on Docker) and the README documents pre-pull and user-systemd notes for rootless Podman.'
+time: 2026-05-18T19:43:22.858932806+10:00

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The service can be started and stopped after being built:
 
 ## Running with Podman
 
-The compose file is compatible with `podman compose` and `podman-compose`. Bind-mount volumes carry the `:Z` SELinux relabel suffix, which is a no-op on Docker but required on SELinux-enabled hosts (RHEL, Fedora, Rocky, Alma).
+The compose file is compatible with `podman compose` and `podman-compose`. Bind-mount volumes carry the `:z` SELinux shared-relabel suffix (and `:ro` where appropriate). On hosts where SELinux is not enforcing — Docker Desktop, macOS, Windows, non-SELinux Linux — the suffix is ignored. On SELinux-enabled hosts (RHEL, Fedora, Rocky, Alma) both Docker and Podman honour `:z`, relabelling the host path to a shared `container_file_t` label so the data is reachable from multiple containers (an analytics container, another importer, etc.) without each one being locked to a private category set.
 
 ```bash
 podman-compose build

--- a/README.md
+++ b/README.md
@@ -88,6 +88,38 @@ The service can be started and stopped after being built:
 2. Stop the service: `docker-compose down`
 3. Stop the service and remove data: `docker-compose down -v`
 
+## Running with Podman
+
+The compose file is compatible with `podman compose` and `podman-compose`. Bind-mount volumes carry the `:Z` SELinux relabel suffix, which is a no-op on Docker but required on SELinux-enabled hosts (RHEL, Fedora, Rocky, Alma).
+
+```bash
+podman-compose build
+podman-compose up -d
+```
+
+### Pre-pull the Postgres image
+
+Podman's default `short-name-mode = "enforcing"` cannot resolve `postgres:14.0-alpine` non-interactively. Pull it with the fully-qualified name before bringing the stack up:
+
+```bash
+podman pull docker.io/library/postgres:14.0-alpine
+```
+
+### Rootless healthchecks need user systemd
+
+Rootless Podman registers container healthchecks as user systemd timers. If your user systemd is unhealthy you will see:
+
+```
+create healthcheck: unable to get systemd connection to add healthchecks:
+  dial unix /run/user/<uid>/systemd/private: connect: connection refused
+```
+
+Re-execute user systemd to refresh the socket:
+
+```bash
+systemctl --user daemon-reexec
+```
+
 ## Development
 
 The Python environment is managed with [pixi](https://pixi.sh). The manifest lives in

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,8 +41,8 @@ services:
     links:
       - pg
     volumes:
-     - ${MIMIC_DATA_PATH}:/usr/src/app/data
-     - ./config.json:/usr/src/app/config.json
+     - ${MIMIC_DATA_PATH}:/usr/src/app/data:Z
+     - ./config.json:/usr/src/app/config.json:Z
     deploy:
       resources:
         limits:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,8 +41,8 @@ services:
     links:
       - pg
     volumes:
-     - ${MIMIC_DATA_PATH}:/usr/src/app/data:Z
-     - ./config.json:/usr/src/app/config.json:Z
+     - ${MIMIC_DATA_PATH}:/usr/src/app/data:z
+     - ./config.json:/usr/src/app/config.json:ro,z
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary
- Add `:Z` SELinux relabel suffix to the two host bind mounts in `docker-compose.yaml` — no-op on Docker, required on SELinux-enabled hosts so rootless Podman can read the data and config volumes.
- Document Podman usage in `README.md`: pre-pull the fully-qualified Postgres image (Podman's enforcing short-name mode cannot resolve `postgres:14.0-alpine` non-interactively) and the `systemctl --user daemon-reexec` workaround for stale rootless healthcheck registration.
- Add a changie `Added` entry for the next release.

Closes #3. Follow-up bug #5 filed for the misleading `ConfigHandler` exception trace that masked the SELinux error during testing.

## Test plan
- [x] `podman-compose build` succeeds
- [x] `podman-compose up -d` brings up `db` and `mimic_import`; `db` becomes `healthy`
- [x] `mimic_import` reads `config.json`, connects to `pg`, creates `mimic_hosp` / `mimic_icu` / `mimiciv_ed` schemas (37 tables)
- [x] Full ED import (MIMIC-IV-ED v2.2): 425k edstays, 899k diagnosis, 2.9M medrecon, 1.5M pyxis, plus triage / vitalsign — exit 0, `MIMIC import completed`
- [x] `podman-compose down -v` cleans up cleanly
- [ ] Docker / docker-compose smoke test on a non-SELinux host (not done in this branch; `:Z` is documented as a no-op there)