### PR TITLE
Fix: initialize self.config=None before try block to prevent AttributeError

### DIFF
--- a/pgmimic/_config/_config_handler.py
+++ b/pgmimic/_config/_config_handler.py
@@ -4,6 +4,7 @@ import os
 
 class ConfigHandler:
     def __init__(self, location: str = None) -> None:
+        self.config = None
         try:
             with open(location) as config_file:
                 self.config = json.load(config_file)


### PR DESCRIPTION
## Fix: ConfigHandler should initialize self.config before try block

Closes #5

**Problem:** In `pgmimic/_config/_config_handler.py`, the `ConfigHandler.__init__` only assigns `self.config` inside a successful `try` block. If the config file load fails (e.g., `PermissionError` due to file permissions), the exception is caught and printed, but `self.config` is **never assigned**.

The caller (`MimicImporter.__init__`) succeeds silently. The first consumer (`MimicImporter.connect()`) then hits `self.config` and raises:
```
AttributeError: 'ConfigHandler' object has no attribute 'config'
```

The real root cause (`PermissionError`) is lost.

**Fix:** Initialize `self.config = None` **before** the try block:
```python
def __init__(self, location: str = None) -> None:
    self.config = None  # Always initialized
    try:
        with open(location) as config_file:
            self.config = json.load(config_file)
            ...
    except Exception as e:
        print(repr(e))
    return None
```

Now callers can check `if handler.config is None` to detect config failure, rather than getting a confusing `AttributeError`.
