### PR TITLE
WIP: Platform expansion plan (multi-engine, DuckDB next)

### DIFF
--- a/docs/platform-plan.md
+++ b/docs/platform-plan.md
@@ -2,30 +2,56 @@
 
 > **Status:** Draft (WIP)
 > **Branch:** `feat/expand-platform`
-> **Scope of this document:** the decisions and module changes needed to add DuckDB as a second engine alongside Postgres, and to rename the project to reflect a multi-engine vision. Future engines (Spark) and platforms (k3s) are deliberately out of scope here.
+> **Scope of this document:** the decisions and module changes needed to add **DuckDB, MySQL, and SQLite** as additional engines alongside Postgres, and to rename the project to reflect a multi-engine vision. Future engines (Spark, BigQuery) and platforms (k3s) are deliberately out of scope here.
 
 ## Goal
 
-Expand `PostgresMimicImporter` from a Postgres-only loader into a multi-engine MIMIC data builder. First addition: **DuckDB as a flat-file artifact** (`mimic.duckdb`). Rename the project to **`MimicDataStack`** to signal that engines and platforms are now composable layers.
+Expand `PostgresMimicImporter` from a Postgres-only loader into a multi-engine MIMIC data builder. First additions: **DuckDB, MySQL, SQLite** — leveraging the engine-specific build artifacts that [MIT-LCP/mimic-code](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iv/buildmimic) already maintains. Rename the project to **`MimicDataStack`** to signal that engines and platforms are now composable layers.
 
 User-facing model after this work:
 
-| Pick an engine | Pick a runtime | Result |
-| --- | --- | --- |
-| `postgresql` | docker / podman | Postgres container on `:5432`, importer loads MIMIC into it (today's behaviour) |
-| `duckdb` | docker / podman | Builder container produces a `mimic.duckdb` file on a mounted volume; open it locally with DuckDB CLI, DataGrip, or any DuckDB client |
+| Engine | Runtime | Result | Output |
+| --- | --- | --- | --- |
+| `postgresql` | docker / podman | Postgres container on `:5432` | Running service (today's behaviour) |
+| `mysql` | docker / podman | MySQL container on `:3306` | Running service |
+| `duckdb` | docker / podman | Builder container | `mimic.duckdb` file on mounted volume |
+| `sqlite` | docker / podman | Builder container | `mimic4.db` file on mounted volume |
+
+The matrix collapses cleanly into two families:
+
+- **Server-mode engines** (Postgres, MySQL) — listen on a TCP port; importer connects, creates schemas/tables, bulk-loads. End state is a long-running service.
+- **File-mode engines** (DuckDB, SQLite) — in-process libraries; the build container produces a single database file and exits. Clients (DataGrip, DBeaver, native CLI) connect to the file directly. There is no port.
 
 ## Constraints discovered during planning
 
-- **DuckDB is in-process.** No TCP port, no client/server wire protocol. The official `duckdb/duckdb` Docker image is a CLI in a container; there is no `:5432`-equivalent.
-- Clients like DataGrip connect to DuckDB by pointing the JDBC driver at a **`.duckdb` file on disk**, not over a network. This pipeline therefore produces a file artifact, not a running service.
-- Docker / Podman are still valuable here: they bundle the build environment so users don't install DuckDB or Python locally to produce the file.
-- Server-mode-style options exist (`pg_duckdb`, MotherDuck, `duckdb-httpserver` community extension, Arrow Flight SQL) but each is a meaningful architectural commitment. **Explicitly out of scope** for this iteration.
+### Server-mode engines
+
+- Postgres and MySQL behave alike at the "runtime container with a port" level. The Postgres path is what exists today; MySQL is symmetrical.
+- MySQL has **no schemas in the Postgres sense** — only databases. This breaks the assumption baked into `config.json` and the existing DDL that `schema.table` is universal. See Decision 3.
+
+### File-mode engines
+
+- **DuckDB is in-process.** No TCP port, no client/server wire protocol. The official `duckdb/duckdb` Docker image is just a CLI in a container.
+- **SQLite is also in-process**, with the same constraint.
+- Server-mode-style options for DuckDB exist (`pg_duckdb`, MotherDuck, `duckdb-httpserver`, Arrow Flight SQL) but each is a meaningful architectural commitment. **Explicitly out of scope** for this iteration.
+- Docker / Podman are still valuable here: they bundle the build environment so users don't install DuckDB / SQLite / Python / pandas locally.
+
+### DDL divergence across engines
+
+This is the most consequential finding. The four engines diverge in DDL compatibility far enough that **one canonical DDL with transforms does not work for all four**:
+
+| Engine | DDL approach in MIT-LCP | Why it can / cannot share PG's DDL |
+| --- | --- | --- |
+| Postgres | Hand-written `create.sql` | Canonical |
+| DuckDB | Same `create.sql` with three regex transforms applied at script runtime | Minor divergence (`TIMESTAMP(N)`, a few `NOT NULL`s) |
+| MySQL | Hand-written `load.sql` (46 KB) | `DATETIME` vs `TIMESTAMP`, `BOOLEAN` vs `SMALLINT`, no schemas, `CHARACTER SET = UTF8MB4`, `LOAD DATA LOCAL INFILE` with per-column `trim()` / NULL conditionals — not regex-transformable from PG |
+| SQLite | `import.py` — schema built **dynamically** from CSV columns via `pandas` | SQLite's dynamic typing makes pre-baked DDL unnecessary |
 
 ## Out of scope (this iteration)
 
-- k3s / Kubernetes manifests for either engine.
+- k3s / Kubernetes manifests for any engine.
 - Spark engine.
+- BigQuery engine (MIT-LCP supports it; cloud-only, deferred).
 - DuckDB-as-server in any form (HTTP extension, MotherDuck, `pg_duckdb`, Flight SQL).
 - Repository rename on GitHub — handled as a separate operation once the in-tree rename lands.
 - Schema changes to MIMIC data itself.
@@ -39,7 +65,7 @@ Already on `main`:
 - **Podman / podman-compose support** (added in `c2d2864`, refined in `6d06394`).
 - Pixi-managed Python environment (added in `6d2b8fc`).
 
-The runtime side of the matrix (docker, podman) is therefore mostly covered; this plan focuses on the **engine** axis.
+The runtime side (docker, podman) is covered. This plan focuses on the **engine** axis.
 
 ### Where Postgres-specific code lives today
 
@@ -48,7 +74,7 @@ The runtime side of the matrix (docker, podman) is therefore mostly covered; thi
 | Concern | Implementation | Postgres-coupled? |
 | --- | --- | --- |
 | Connection | `psycopg2.connect()` (line 13) | Yes |
-| Existence check | `information_schema.tables` query (lines 36-41) | Mostly (DuckDB supports `information_schema` too) |
+| Existence check | `information_schema.tables` query (lines 36-41) | Mostly (DuckDB and MySQL also have it; SQLite uses `sqlite_master`) |
 | DDL application | Reads `_db/SQL/{version}/*.sql`, naive `split(";")` (lines 102-121) | Yes — DDL is Postgres syntax |
 | Bulk load | Shells out to `psql` with `\copy ... FROM PROGRAM 'gzip -dc ...'` (lines 143-167) | Heavily |
 
@@ -69,10 +95,13 @@ mimicstack/
     ├── engine.py                     # NEW: Engine Protocol + make_engine factory
     ├── postgres_engine.py            # NEW: existing PG logic, mechanically moved
     ├── duckdb_engine.py              # NEW: in-process duckdb Python package
+    ├── mysql_engine.py               # NEW: PyMySQL or mysql-connector-python
+    ├── sqlite_engine.py              # NEW: stdlib sqlite3 + pandas
     └── SQL/
         └── 2.2/
             ├── postgres/             # MOVED: existing *.sql, unchanged
-            └── (no duckdb/ folder)   # DuckDB DDL is generated at runtime — see Decision 1
+            ├── mysql/                # NEW: vendored copy of MIT-LCP load.sql
+            └── (no duckdb/, no sqlite/)   # DDL generated at runtime — see Decision 1
 ```
 
 ### Engine contract
@@ -87,33 +116,46 @@ class Engine(Protocol):
     def connect(self) -> None: ...
     def close(self) -> None: ...
     def data_exists(self, schemas: dict[str, list[str]]) -> bool: ...
-    def apply_ddl(self, sql_path: Path) -> None: ...
+    def apply_ddl(self, schemas: dict[str, list[str]]) -> None: ...   # may be no-op for SQLite
     def load_table(self, schema: str, table: str, csv_gz_path: Path) -> None: ...
-    def apply_post_load(self) -> None: ...   # PG functions on PG; no-op on DuckDB
+    def apply_post_load(self) -> None: ...   # PG functions on PG; no-op elsewhere
 
 
 def make_engine(config: dict) -> Engine:
     db = config["database"]
     match db["type"]:
         case "postgresql":
-            return PostgresEngine(
-                host=db["host"], port=db["port"],
-                database=db["database"], schema=db["schema"],
-                user=db["username"], password=db["password"],
-            )
+            return PostgresEngine(host=db["host"], port=db["port"], database=db["database"],
+                                  schema=db["schema"], user=db["username"], password=db["password"])
+        case "mysql":
+            return MySQLEngine(host=db["host"], port=db["port"], database=db["database"],
+                               user=db["user"], password=db["password"])
         case "duckdb":
             return DuckDBEngine(path=Path(db["path"]))
+        case "sqlite":
+            return SQLiteEngine(path=Path(db["path"]))
         case t:
             raise ValueError(f"unknown engine type: {t!r}")
 ```
 
 `MimicImporter` collapses to a ~30-line orchestrator that depends only on `Engine`; no `psycopg2` import survives outside `postgres_engine.py`.
 
+**Note on `apply_ddl()` signature:** changed from `apply_ddl(sql_path: Path)` to `apply_ddl(schemas: dict[str, list[str]])`. This is to accommodate engines that build schema dynamically (SQLite) or have no schema concept at all (MySQL's flat namespace, depending on Decision 3). Each engine decides how to materialise the structured schema info — by reading a SQL file, by transforming one, by introspecting CSVs, or by issuing `CREATE DATABASE` per schema.
+
 ## Decisions
 
-### Decision 1 — DDL strategy: canonical Postgres + regex transforms
+### Decision 1 — DDL strategy: per-engine, three different approaches
 
-**Chosen.** Postgres DDL remains the single source of truth. `DuckDBEngine.apply_ddl` applies three regex transforms (lifted from MIT-LCP's `mimic-iv/buildmimic/duckdb/import_duckdb.sh`) before executing:
+**Chosen.** A single canonical DDL across all four engines was the original plan, but inspection of MIT-LCP's per-engine artifacts shows the divergence is too large. Each engine uses the artifact that best matches its model:
+
+| Engine | DDL source | Lives in |
+| --- | --- | --- |
+| Postgres | Existing hand-written `create.sql` (canonical for *this project*) | `_db/SQL/2.2/postgres/` |
+| DuckDB | Postgres DDL + 3 regex transforms at runtime | Generated; no file |
+| MySQL | Vendored copy of MIT-LCP's `mimic-iv/buildmimic/mysql/load.sql` | `_db/SQL/2.2/mysql/` |
+| SQLite | Generated dynamically from CSV columns via `pandas` | Generated; no file |
+
+DuckDB transforms (lifted from MIT-LCP's `mimic-iv/buildmimic/duckdb/import_duckdb.sh`):
 
 | # | Pattern | Replacement | Why |
 | --- | --- | --- | --- |
@@ -121,32 +163,29 @@ def make_engine(config: dict) -> Engine:
 | 2 | `spec_type_desc(.+)NOT NULL` | `spec_type_desc\1` | One zero-length string in source data, treated as NULL by DuckDB import |
 | 3 | `drug +(VARCHAR.+)NOT NULL` | `drug \1` | Multiple zero-length strings in source data |
 
-**Trade-off accepted:** single source of truth for DDL; transforms live in Python and are easy to extend. **Risk:** future Postgres-isms in upstream MIMIC DDL may require new regexes.
+**Trade-off accepted:** each engine carries the artifact best-suited to its idioms; PRs that update a single engine touch one file. **Risk:** drift between engines when MIMIC schema versions change — each engine's DDL needs an independent update from MIT-LCP upstream. Mitigation: pin the MIT-LCP commit hash in `docs/upstream-sources.md` (future doc) so updates are auditable.
 
 **Alternatives considered:**
 
-- *Per-engine SQL files* — rejected: dual maintenance burden whenever MIMIC schema changes.
-- *SQLGlot transpilation* — rejected for now: adds a heavy dependency for only three currently-known divergences. Reconsider if the regex list grows beyond ~6 patterns.
+- *Single canonical PG DDL + transforms for every engine* — rejected: MySQL diverges too far (type system, namespace, load syntax); SQLite has no use for pre-baked DDL.
+- *SQLGlot transpilation* — rejected for DuckDB (overkill for 3 regexes), unsuitable for MySQL (transpilation doesn't generate `LOAD DATA LOCAL INFILE` clauses), inapplicable for SQLite (dynamic schema).
 
 ### Decision 2 — Config shape: discriminated union by `type`
 
 **Chosen.** Each engine reads only its own block; `make_engine` enforces the shape per type.
 
 ```jsonc
-// Postgres (existing shape, but drop the "+asyncpg" suffix — psycopg2 is what we use)
-"database": {
-  "type": "postgresql",
-  "host": "pg",
-  "port": 5432,
-  "database": "postgres",
-  "schema": "public"
-}
+// Postgres (existing shape; drop "+asyncpg" suffix — psycopg2 is what we use)
+"database": { "type": "postgresql", "host": "pg", "port": 5432, "database": "postgres", "schema": "public" }
+
+// MySQL (new)
+"database": { "type": "mysql", "host": "mysql", "port": 3306, "database": "mimic" }
 
 // DuckDB (new)
-"database": {
-  "type": "duckdb",
-  "path": "/data/mimic.duckdb"
-}
+"database": { "type": "duckdb", "path": "/data/mimic.duckdb" }
+
+// SQLite (new)
+"database": { "type": "sqlite", "path": "/data/mimic4.db" }
 ```
 
 **Trade-off accepted:** cleanest engine boundary; invalid fields surface immediately at engine construction. **Risk:** small backwards-incompatibility for anyone with a hand-edited `config.json` using `"postgresql+asyncpg"` — a one-character migration; note in CHANGELOG.
@@ -154,38 +193,66 @@ def make_engine(config: dict) -> Engine:
 **Alternatives considered:**
 
 - *Optional fields, engine ignores what it doesn't need* — rejected: hides config errors until runtime.
-- *Nested per-engine blocks (`{"engine": ..., "postgres": {...}, "duckdb": {...}}`)* — rejected: most blocks are dead at any given moment; verbosity without benefit.
+- *Nested per-engine blocks* — rejected: most blocks dead at any moment; verbose without benefit.
+
+### Decision 3 — MySQL schema model
+
+MySQL has no `schema` concept in the Postgres sense; it has *databases*. The existing config / DDL assumes `mimic_hosp.admissions`-style schema-qualified names. Three options for MySQL:
+
+| Option | Mapping | Trade-off |
+| --- | --- | --- |
+| (a) One DB per schema | `mimic_hosp.admissions` → DB `mimic_hosp`, table `admissions` | Preserves structural grouping; importer must `CREATE DATABASE` per schema and switch contexts (`USE db` or fully-qualified names). Multiple JDBC connections from one client to query across "schemas". |
+| (b) Single DB, prefixed tables | `mimic_hosp.admissions` → `mimic_hosp__admissions` in one DB | One connection from any client. Loses semantic grouping in tooling. |
+| (c) Single DB, flat (MIT-LCP's choice) | `admissions` (no prefix) | Simplest. Loses the hosp/icu/ed/derived separation entirely. |
+
+**Recommendation:** (a) — preserves the structural grouping that exists in every other engine in this stack, in exchange for some importer complexity. The cross-engine consistency is worth more than the per-engine simplicity.
+
+**Status:** unconfirmed — needs sign-off before Phase 3b.
 
 ### Bulk-load mechanics per engine
 
-- **Postgres** (unchanged): `\copy ... FROM PROGRAM 'gzip -dc ...'` via shelled-out `psql`.
-- **DuckDB** (new): native gzip support, no decompression pipe:
-
-  ```sql
-  COPY {schema}.{table}
-  FROM '{csv_gz_path}'
-  (HEADER, DELIM ',', QUOTE '"', ESCAPE '"', COMPRESSION 'gzip');
-  ```
+| Engine | Mechanism | Notes |
+| --- | --- | --- |
+| Postgres | `\copy ... FROM PROGRAM 'gzip -dc ...'` via shelled-out `psql` | Unchanged from today |
+| MySQL | `LOAD DATA LOCAL INFILE '...' INTO TABLE ... FIELDS TERMINATED BY ',' ...` | Requires `local_infile=1` server-side and on client; per-column `trim()` / NULL handling per MIT-LCP `load.sql` |
+| DuckDB | `COPY {schema}.{table} FROM '{path}' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"', COMPRESSION 'gzip')` | DuckDB reads `.csv.gz` natively, no decompression pipe |
+| SQLite | `pandas.read_csv(...)` then `df.to_sql(table, conn, chunksize=10**6)` | Per MIT-LCP `import.py`; chunked for memory; dynamic schema inferred from CSV |
 
 ## Open questions
 
-### Schema naming alignment
+### Schema naming alignment (cross-engine)
 
-MIT-LCP's DuckDB script writes to `mimiciv_hosp` / `mimiciv_icu`. This repo's Postgres side uses `mimic_hosp` / `mimic_icu`. Because we share a single canonical DDL across engines, both engines will produce identical schema names — they cannot diverge by construction.
+MIT-LCP's DuckDB script writes to `mimiciv_hosp` / `mimiciv_icu`. MIT-LCP's MySQL `load.sql` uses no schemas at all (option (c) above). This repo's Postgres side uses `mimic_hosp` / `mimic_icu`.
 
-**Recommendation:** keep this repo's existing `mimic_hosp` / `mimic_icu`. Users coming from MIT-LCP's DuckDB notebooks will need to rename schemas in their queries; that's an accepted, one-time cost in exchange for internal consistency between the engines this project ships.
+**Recommendation:** keep this repo's existing `mimic_hosp` / `mimic_icu` everywhere. Users coming from MIT-LCP's DuckDB notebooks or MySQL examples will need to rename schemas / tables in queries — accepted one-time cost for internal consistency across the four engines this project ships.
 
-**Status:** unconfirmed — needs sign-off before Phase 3.
+**Status:** unconfirmed — sign off in conjunction with Decision 3.
+
+### Pandas dependency for SQLite
+
+`SQLiteEngine` needs `pandas` if we follow MIT-LCP's `import.py` approach. Pandas is a heavy dependency (numpy transitively). Alternatives:
+
+- *Stream CSV with stdlib `csv` + `executemany`* — much smaller dep footprint; more code to write; we re-invent MIT-LCP's logic.
+- *Accept pandas as a SQLite-only dependency* — `pixi.toml` can scope the dep to the `sqlite-builder` feature so the Postgres importer image stays slim.
+
+**Recommendation:** scope pandas to the SQLite builder via pixi features; don't make every install pay for it.
+
+**Status:** unconfirmed.
 
 ## Image / packaging changes
 
 Today: one `mimic_import.dockerfile` installs `postgresql-client`.
 
-Target:
+Target — one builder/importer image per engine, scoped via pixi features:
 
-- `images/postgres-importer.dockerfile` — current image, unchanged behaviour.
-- `images/duckdb-builder.dockerfile` — slim Python + `pip install duckdb`. No client binaries. Output: `mimic.duckdb` file on a mounted volume.
-- `docker-compose.yaml` either stays Postgres-focused or grows a `--profile duckdb`. Decide during Phase 4 when the actual surface area is visible.
+| Image | Base | Engine deps | Output |
+| --- | --- | --- | --- |
+| `images/postgres-importer.dockerfile` | python-slim | `psycopg2`, `postgresql-client` (binary) | Loads into running PG container |
+| `images/mysql-importer.dockerfile` | python-slim | `PyMySQL` or `mysql-connector-python`, `mysql-client` (for `LOAD DATA LOCAL INFILE`) | Loads into running MySQL container |
+| `images/duckdb-builder.dockerfile` | python-slim | `duckdb` (pip) | `mimic.duckdb` on mounted volume |
+| `images/sqlite-builder.dockerfile` | python-slim | `pandas`, `sqlite3` (stdlib) | `mimic4.db` on mounted volume |
+
+`docker-compose.yaml` grows compose profiles per engine (e.g. `docker compose --profile duckdb up`); decide concrete shape during Phase 4.
 
 ## Implementation phases
 
@@ -196,12 +263,17 @@ Each phase is a reviewable PR. Later phases assume earlier ones are merged.
 | 0 | This plan doc | None |
 | 1 | Module rename `pgmimic/` → `mimicstack/`; no behaviour change | Low — pure rename + import-path fixups |
 | 2 | Scaffold `Engine` Protocol + `make_engine`; move existing PG logic into `PostgresEngine` behind the new interface | Medium — refactor of working code, needs end-to-end smoke test |
-| 3 | Add `DuckDBEngine` with the three regex DDL transforms + native `csv.gz` load | Medium — new dependency, new code path |
-| 4 | New Dockerfile for DuckDB builder; docker-compose profile or separate compose file | Low — packaging |
+| 3a | Add `DuckDBEngine` with three regex DDL transforms + native `csv.gz` load | Medium — new dep, new code path |
+| 3b | Add `MySQLEngine`: vendor MIT-LCP `load.sql`, `LOAD DATA LOCAL INFILE`, MySQL container in compose | Medium-high — schema model decision, MySQL-specific load quirks (`local_infile`) |
+| 3c | Add `SQLiteEngine`: port MIT-LCP `import.py` approach (pandas chunked load + dynamic schema) | Medium — new dep (pandas), scoped via pixi |
+| 4 | Per-engine Dockerfiles + compose profiles | Low — packaging |
 | 5 | README rewrite; rename GitHub repository to `MimicDataStack` | Low — coordination only |
+
+Phases 3a / 3b / 3c can in principle proceed in parallel after Phase 2 lands, but reviewing them serially is recommended to catch Engine-contract issues that surface only when the second or third implementation reveals an unworkable abstraction.
 
 ## Future work (deliberately deferred)
 
 - **Spark engine** slotting into the same `Engine` Protocol: `{"type": "spark", "master": "spark://...", "warehouse": "s3://..."}`. The `match` statement in `make_engine` is the extension point.
-- **k3s deployment** — Helm chart for the Postgres path. The DuckDB path is unlikely to benefit (in-process file producer; nothing to orchestrate).
+- **BigQuery engine** — MIT-LCP supports it (`mimic-iv/buildmimic/bigquery/`); cloud-only, deferred until cloud-account onboarding story is solved.
+- **k3s deployment** — Helm chart for the Postgres and MySQL paths. The file-mode engines (DuckDB, SQLite) won't benefit (in-process file producers; nothing to orchestrate).
 - **DuckDB server-mode** — revisit if/when DuckDB ships a stable wire protocol that JDBC clients can speak directly.

--- a/docs/platform-plan.md
+++ b/docs/platform-plan.md
@@ -1,0 +1,207 @@
+# Platform Expansion Plan
+
+> **Status:** Draft (WIP)
+> **Branch:** `feat/expand-platform`
+> **Scope of this document:** the decisions and module changes needed to add DuckDB as a second engine alongside Postgres, and to rename the project to reflect a multi-engine vision. Future engines (Spark) and platforms (k3s) are deliberately out of scope here.
+
+## Goal
+
+Expand `PostgresMimicImporter` from a Postgres-only loader into a multi-engine MIMIC data builder. First addition: **DuckDB as a flat-file artifact** (`mimic.duckdb`). Rename the project to **`MimicDataStack`** to signal that engines and platforms are now composable layers.
+
+User-facing model after this work:
+
+| Pick an engine | Pick a runtime | Result |
+| --- | --- | --- |
+| `postgresql` | docker / podman | Postgres container on `:5432`, importer loads MIMIC into it (today's behaviour) |
+| `duckdb` | docker / podman | Builder container produces a `mimic.duckdb` file on a mounted volume; open it locally with DuckDB CLI, DataGrip, or any DuckDB client |
+
+## Constraints discovered during planning
+
+- **DuckDB is in-process.** No TCP port, no client/server wire protocol. The official `duckdb/duckdb` Docker image is a CLI in a container; there is no `:5432`-equivalent.
+- Clients like DataGrip connect to DuckDB by pointing the JDBC driver at a **`.duckdb` file on disk**, not over a network. This pipeline therefore produces a file artifact, not a running service.
+- Docker / Podman are still valuable here: they bundle the build environment so users don't install DuckDB or Python locally to produce the file.
+- Server-mode-style options exist (`pg_duckdb`, MotherDuck, `duckdb-httpserver` community extension, Arrow Flight SQL) but each is a meaningful architectural commitment. **Explicitly out of scope** for this iteration.
+
+## Out of scope (this iteration)
+
+- k3s / Kubernetes manifests for either engine.
+- Spark engine.
+- DuckDB-as-server in any form (HTTP extension, MotherDuck, `pg_duckdb`, Flight SQL).
+- Repository rename on GitHub — handled as a separate operation once the in-tree rename lands.
+- Schema changes to MIMIC data itself.
+
+## Current state
+
+Already on `main`:
+
+- Postgres importer (`pgmimic/` package, `psycopg2` + shelled-out `psql` for bulk load).
+- Docker support (`docker-compose.yaml`, `mimic_import.dockerfile`).
+- **Podman / podman-compose support** (added in `c2d2864`, refined in `6d06394`).
+- Pixi-managed Python environment (added in `6d2b8fc`).
+
+The runtime side of the matrix (docker, podman) is therefore mostly covered; this plan focuses on the **engine** axis.
+
+### Where Postgres-specific code lives today
+
+`pgmimic/_db/_db_handler.py:1-169` is a single `DataHandler` class mashing four concerns:
+
+| Concern | Implementation | Postgres-coupled? |
+| --- | --- | --- |
+| Connection | `psycopg2.connect()` (line 13) | Yes |
+| Existence check | `information_schema.tables` query (lines 36-41) | Mostly (DuckDB supports `information_schema` too) |
+| DDL application | Reads `_db/SQL/{version}/*.sql`, naive `split(";")` (lines 102-121) | Yes — DDL is Postgres syntax |
+| Bulk load | Shells out to `psql` with `\copy ... FROM PROGRAM 'gzip -dc ...'` (lines 143-167) | Heavily |
+
+`pgmimic/_files/_file_handler.py` and `pgmimic/_config/_config_handler.py` are mostly engine-neutral already and need only minor adjustments.
+
+## Target architecture
+
+### Module layout
+
+Rename `pgmimic/` → `mimicstack/`. Within it, split the engine concern out of `DataHandler`:
+
+```
+mimicstack/
+├── _config/_config_handler.py        # adds engine-aware validation
+├── _files/_file_handler.py           # unchanged
+├── importer/mimic_importer.py        # depends on Engine, not DataHandler
+└── _db/
+    ├── engine.py                     # NEW: Engine Protocol + make_engine factory
+    ├── postgres_engine.py            # NEW: existing PG logic, mechanically moved
+    ├── duckdb_engine.py              # NEW: in-process duckdb Python package
+    └── SQL/
+        └── 2.2/
+            ├── postgres/             # MOVED: existing *.sql, unchanged
+            └── (no duckdb/ folder)   # DuckDB DDL is generated at runtime — see Decision 1
+```
+
+### Engine contract
+
+```python
+# mimicstack/_db/engine.py  (sketch — not yet implemented)
+from pathlib import Path
+from typing import Protocol
+
+
+class Engine(Protocol):
+    def connect(self) -> None: ...
+    def close(self) -> None: ...
+    def data_exists(self, schemas: dict[str, list[str]]) -> bool: ...
+    def apply_ddl(self, sql_path: Path) -> None: ...
+    def load_table(self, schema: str, table: str, csv_gz_path: Path) -> None: ...
+    def apply_post_load(self) -> None: ...   # PG functions on PG; no-op on DuckDB
+
+
+def make_engine(config: dict) -> Engine:
+    db = config["database"]
+    match db["type"]:
+        case "postgresql":
+            return PostgresEngine(
+                host=db["host"], port=db["port"],
+                database=db["database"], schema=db["schema"],
+                user=db["username"], password=db["password"],
+            )
+        case "duckdb":
+            return DuckDBEngine(path=Path(db["path"]))
+        case t:
+            raise ValueError(f"unknown engine type: {t!r}")
+```
+
+`MimicImporter` collapses to a ~30-line orchestrator that depends only on `Engine`; no `psycopg2` import survives outside `postgres_engine.py`.
+
+## Decisions
+
+### Decision 1 — DDL strategy: canonical Postgres + regex transforms
+
+**Chosen.** Postgres DDL remains the single source of truth. `DuckDBEngine.apply_ddl` applies three regex transforms (lifted from MIT-LCP's `mimic-iv/buildmimic/duckdb/import_duckdb.sh`) before executing:
+
+| # | Pattern | Replacement | Why |
+| --- | --- | --- | --- |
+| 1 | `TIMESTAMP\([0-9]+\)` | `TIMESTAMP` | DuckDB rejects `TIMESTAMP(N)` precision syntax |
+| 2 | `spec_type_desc(.+)NOT NULL` | `spec_type_desc\1` | One zero-length string in source data, treated as NULL by DuckDB import |
+| 3 | `drug +(VARCHAR.+)NOT NULL` | `drug \1` | Multiple zero-length strings in source data |
+
+**Trade-off accepted:** single source of truth for DDL; transforms live in Python and are easy to extend. **Risk:** future Postgres-isms in upstream MIMIC DDL may require new regexes.
+
+**Alternatives considered:**
+
+- *Per-engine SQL files* — rejected: dual maintenance burden whenever MIMIC schema changes.
+- *SQLGlot transpilation* — rejected for now: adds a heavy dependency for only three currently-known divergences. Reconsider if the regex list grows beyond ~6 patterns.
+
+### Decision 2 — Config shape: discriminated union by `type`
+
+**Chosen.** Each engine reads only its own block; `make_engine` enforces the shape per type.
+
+```jsonc
+// Postgres (existing shape, but drop the "+asyncpg" suffix — psycopg2 is what we use)
+"database": {
+  "type": "postgresql",
+  "host": "pg",
+  "port": 5432,
+  "database": "postgres",
+  "schema": "public"
+}
+
+// DuckDB (new)
+"database": {
+  "type": "duckdb",
+  "path": "/data/mimic.duckdb"
+}
+```
+
+**Trade-off accepted:** cleanest engine boundary; invalid fields surface immediately at engine construction. **Risk:** small backwards-incompatibility for anyone with a hand-edited `config.json` using `"postgresql+asyncpg"` — a one-character migration; note in CHANGELOG.
+
+**Alternatives considered:**
+
+- *Optional fields, engine ignores what it doesn't need* — rejected: hides config errors until runtime.
+- *Nested per-engine blocks (`{"engine": ..., "postgres": {...}, "duckdb": {...}}`)* — rejected: most blocks are dead at any given moment; verbosity without benefit.
+
+### Bulk-load mechanics per engine
+
+- **Postgres** (unchanged): `\copy ... FROM PROGRAM 'gzip -dc ...'` via shelled-out `psql`.
+- **DuckDB** (new): native gzip support, no decompression pipe:
+
+  ```sql
+  COPY {schema}.{table}
+  FROM '{csv_gz_path}'
+  (HEADER, DELIM ',', QUOTE '"', ESCAPE '"', COMPRESSION 'gzip');
+  ```
+
+## Open questions
+
+### Schema naming alignment
+
+MIT-LCP's DuckDB script writes to `mimiciv_hosp` / `mimiciv_icu`. This repo's Postgres side uses `mimic_hosp` / `mimic_icu`. Because we share a single canonical DDL across engines, both engines will produce identical schema names — they cannot diverge by construction.
+
+**Recommendation:** keep this repo's existing `mimic_hosp` / `mimic_icu`. Users coming from MIT-LCP's DuckDB notebooks will need to rename schemas in their queries; that's an accepted, one-time cost in exchange for internal consistency between the engines this project ships.
+
+**Status:** unconfirmed — needs sign-off before Phase 3.
+
+## Image / packaging changes
+
+Today: one `mimic_import.dockerfile` installs `postgresql-client`.
+
+Target:
+
+- `images/postgres-importer.dockerfile` — current image, unchanged behaviour.
+- `images/duckdb-builder.dockerfile` — slim Python + `pip install duckdb`. No client binaries. Output: `mimic.duckdb` file on a mounted volume.
+- `docker-compose.yaml` either stays Postgres-focused or grows a `--profile duckdb`. Decide during Phase 4 when the actual surface area is visible.
+
+## Implementation phases
+
+Each phase is a reviewable PR. Later phases assume earlier ones are merged.
+
+| Phase | Scope | Risk |
+| --- | --- | --- |
+| 0 | This plan doc | None |
+| 1 | Module rename `pgmimic/` → `mimicstack/`; no behaviour change | Low — pure rename + import-path fixups |
+| 2 | Scaffold `Engine` Protocol + `make_engine`; move existing PG logic into `PostgresEngine` behind the new interface | Medium — refactor of working code, needs end-to-end smoke test |
+| 3 | Add `DuckDBEngine` with the three regex DDL transforms + native `csv.gz` load | Medium — new dependency, new code path |
+| 4 | New Dockerfile for DuckDB builder; docker-compose profile or separate compose file | Low — packaging |
+| 5 | README rewrite; rename GitHub repository to `MimicDataStack` | Low — coordination only |
+
+## Future work (deliberately deferred)
+
+- **Spark engine** slotting into the same `Engine` Protocol: `{"type": "spark", "master": "spark://...", "warehouse": "s3://..."}`. The `match` statement in `make_engine` is the extension point.
+- **k3s deployment** — Helm chart for the Postgres path. The DuckDB path is unlikely to benefit (in-process file producer; nothing to orchestrate).
+- **DuckDB server-mode** — revisit if/when DuckDB ships a stable wire protocol that JDBC clients can speak directly.

--- a/docs/platform-plan.md
+++ b/docs/platform-plan.md
@@ -1,12 +1,12 @@
 # Platform Expansion Plan
 
-> **Status:** Draft (WIP)
+> **Status:** Draft (WIP) — revised after independent review.
 > **Branch:** `feat/expand-platform`
-> **Scope of this document:** the decisions and module changes needed to add **DuckDB, MySQL, and SQLite** as additional engines alongside Postgres, and to rename the project to reflect a multi-engine vision. Future engines (Spark, BigQuery) and platforms (k3s) are deliberately out of scope here.
+> **Scope of this document:** the decisions and module changes needed to add **DuckDB, MySQL, and SQLite** as additional engines alongside Postgres. A rebrand to `MimicDataStack` is *contingent* on the multi-engine premise being proven (see Phase 5); it is not a commitment of this plan.
 
 ## Goal
 
-Expand `PostgresMimicImporter` from a Postgres-only loader into a multi-engine MIMIC data builder. First additions: **DuckDB, MySQL, SQLite** — leveraging the engine-specific build artifacts that [MIT-LCP/mimic-code](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iv/buildmimic) already maintains. Rename the project to **`MimicDataStack`** to signal that engines and platforms are now composable layers.
+Expand `PostgresMimicImporter` from a Postgres-only loader into a multi-engine MIMIC data builder by reusing the per-engine build artifacts that [MIT-LCP/mimic-code](https://github.com/MIT-LCP/mimic-code/tree/main/mimic-iv/buildmimic) already maintains.
 
 User-facing model after this work:
 
@@ -17,35 +17,58 @@ User-facing model after this work:
 | `duckdb` | docker / podman | Builder container | `mimic.duckdb` file on mounted volume |
 | `sqlite` | docker / podman | Builder container | `mimic4.db` file on mounted volume |
 
-The matrix collapses cleanly into two families:
+The four engines split into two families:
 
-- **Server-mode engines** (Postgres, MySQL) — listen on a TCP port; importer connects, creates schemas/tables, bulk-loads. End state is a long-running service.
-- **File-mode engines** (DuckDB, SQLite) — in-process libraries; the build container produces a single database file and exits. Clients (DataGrip, DBeaver, native CLI) connect to the file directly. There is no port.
+- **Server-mode** (Postgres, MySQL) — listen on a TCP port; importer connects, creates namespaces/tables, bulk-loads. End state is a long-running service.
+- **File-mode** (DuckDB, SQLite) — in-process libraries; the build container produces a single database file and exits. Clients (DataGrip, DBeaver, native CLI) connect to the file directly. There is no port.
 
 ## Constraints discovered during planning
 
 ### Server-mode engines
 
-- Postgres and MySQL behave alike at the "runtime container with a port" level. The Postgres path is what exists today; MySQL is symmetrical.
-- MySQL has **no schemas in the Postgres sense** — only databases. This breaks the assumption baked into `config.json` and the existing DDL that `schema.table` is universal. See Decision 3.
+- Postgres and MySQL behave alike at the "runtime container with a port" level.
+- **MySQL has no schemas in the Postgres sense** — only databases. The upstream MIT-LCP MySQL DDL is namespace-flat. See Decision 3.
+- **MySQL DDL is implicitly auto-committed** — no transactional DDL. Partial failures leave the database half-built; failure semantics must handle this explicitly. See "Failure semantics."
 
 ### File-mode engines
 
-- **DuckDB is in-process.** No TCP port, no client/server wire protocol. The official `duckdb/duckdb` Docker image is just a CLI in a container.
-- **SQLite is also in-process**, with the same constraint.
+- **DuckDB and SQLite are in-process.** No TCP port; no client/server wire protocol. Clients open the file directly.
+- DuckDB supports `CREATE SCHEMA` natively; SQLite does not (only `ATTACH DATABASE`, which is a different model). Therefore SQLite is forced into flat-table naming, matching MIT-LCP's `import.py`. See Decision 3.
 - Server-mode-style options for DuckDB exist (`pg_duckdb`, MotherDuck, `duckdb-httpserver`, Arrow Flight SQL) but each is a meaningful architectural commitment. **Explicitly out of scope** for this iteration.
-- Docker / Podman are still valuable here: they bundle the build environment so users don't install DuckDB / SQLite / Python / pandas locally.
+
+### Cross-engine namespace inconsistency (accepted)
+
+| Engine | Namespace model | Source |
+| --- | --- | --- |
+| Postgres | Schemas (`mimic_hosp.admissions`) | Our existing DDL |
+| DuckDB | Schemas (`mimic_hosp.admissions`) | PG DDL + 3 regex transforms |
+| MySQL | Flat tables (`admissions`) | Vendored from MIT-LCP `load.sql` |
+| SQLite | Flat tables (`admissions`) | Built dynamically by ported MIT-LCP `import.py` |
+
+This asymmetry is an accepted trade-off, not a bug. Forcing schemas onto MySQL/SQLite would require maintaining our own DDL fork and breaking compatibility with MIT-LCP's reference implementations — see "Future work" for the eventual unification option.
 
 ### DDL divergence across engines
 
-This is the most consequential finding. The four engines diverge in DDL compatibility far enough that **one canonical DDL with transforms does not work for all four**:
-
-| Engine | DDL approach in MIT-LCP | Why it can / cannot share PG's DDL |
+| Engine | DDL source | Why it diverges |
 | --- | --- | --- |
-| Postgres | Hand-written `create.sql` | Canonical |
-| DuckDB | Same `create.sql` with three regex transforms applied at script runtime | Minor divergence (`TIMESTAMP(N)`, a few `NOT NULL`s) |
-| MySQL | Hand-written `load.sql` (46 KB) | `DATETIME` vs `TIMESTAMP`, `BOOLEAN` vs `SMALLINT`, no schemas, `CHARACTER SET = UTF8MB4`, `LOAD DATA LOCAL INFILE` with per-column `trim()` / NULL conditionals — not regex-transformable from PG |
-| SQLite | `import.py` — schema built **dynamically** from CSV columns via `pandas` | SQLite's dynamic typing makes pre-baked DDL unnecessary |
+| Postgres | Hand-written `create.sql` (this repo) | Canonical for this project |
+| DuckDB | PG DDL + 3 regex transforms at runtime | Minor divergence (`TIMESTAMP(N)`, two `NOT NULL`s) |
+| MySQL | **Generated upstream by `csv2mysql`**, vendored as `load.sql` (46 KB) | `DATETIME` vs `TIMESTAMP`, `BOOLEAN` vs `SMALLINT`, no schemas, `CHARACTER SET = UTF8MB4`, `LOAD DATA LOCAL INFILE` with per-column `trim()` / NULL conditionals — not regex-transformable from PG |
+| SQLite | Built dynamically from CSV columns via `pandas.read_csv` | SQLite's dynamic typing makes pre-baked DDL unnecessary |
+
+The MySQL `load.sql` is *generated*, not hand-written — the file header confirms `csv2mysql -o 1-load-no-keys.sql ...`. We vendor it as-is; updates from upstream are regenerated upstream, not edited by us.
+
+## Upstream source pinning
+
+We vendor or port behaviour from three MIT-LCP files. Pin them by commit SHA and blob SHA so future updates are auditable.
+
+| Engine | Upstream path | Commit SHA | Blob SHA |
+| --- | --- | --- | --- |
+| DuckDB | `mimic-iv/buildmimic/duckdb/import_duckdb.sh` | `5706978309` | `3181611c16` |
+| MySQL | `mimic-iv/buildmimic/mysql/load.sql` | `5706978309` | `4570f4da39` |
+| SQLite | `mimic-iv/buildmimic/sqlite/import.py` | `5706978309` | `1cb8eb0d2d` |
+
+Pinned commit: [`5706978309`](https://github.com/MIT-LCP/mimic-code/commit/57069783095e7770e66ea97da264c0200078ddbf) (2025-11-10). When refreshing, update the table above in the same PR that re-vendors.
 
 ## Out of scope (this iteration)
 
@@ -53,7 +76,8 @@ This is the most consequential finding. The four engines diverge in DDL compatib
 - Spark engine.
 - BigQuery engine (MIT-LCP supports it; cloud-only, deferred).
 - DuckDB-as-server in any form (HTTP extension, MotherDuck, `pg_duckdb`, Flight SQL).
-- Repository rename on GitHub — handled as a separate operation once the in-tree rename lands.
+- GitHub repository rename — **contingent on Phase 3a succeeding**; see Phase 5.
+- Per-DB MySQL schemas (would unify the namespace model across engines but requires forking MIT-LCP's MySQL DDL). See "Future work."
 - Schema changes to MIMIC data itself.
 
 ## Current state
@@ -74,17 +98,17 @@ The runtime side (docker, podman) is covered. This plan focuses on the **engine*
 | Concern | Implementation | Postgres-coupled? |
 | --- | --- | --- |
 | Connection | `psycopg2.connect()` (line 13) | Yes |
-| Existence check | `information_schema.tables` query (lines 36-41) | Mostly (DuckDB and MySQL also have it; SQLite uses `sqlite_master`) |
-| DDL application | Reads `_db/SQL/{version}/*.sql`, naive `split(";")` (lines 102-121) | Yes — DDL is Postgres syntax |
+| Existence check | `information_schema.tables` query (lines 36-41) | Mostly |
+| DDL application | Reads `_db/SQL/{version}/*.sql`, naive `split(";")` (lines 102-121) | Yes |
 | Bulk load | Shells out to `psql` with `\copy ... FROM PROGRAM 'gzip -dc ...'` (lines 143-167) | Heavily |
 
-`pgmimic/_files/_file_handler.py` and `pgmimic/_config/_config_handler.py` are mostly engine-neutral already and need only minor adjustments.
+`pgmimic/_files/_file_handler.py` and `pgmimic/_config/_config_handler.py` are mostly engine-neutral already.
 
 ## Target architecture
 
 ### Module layout
 
-Rename `pgmimic/` → `mimicstack/`. Within it, split the engine concern out of `DataHandler`:
+In-tree rename `pgmimic/` → `mimicstack/`. (The user-facing `MimicDataStack` rebrand is separate and conditional — see Phase 5.)
 
 ```
 mimicstack/
@@ -95,16 +119,21 @@ mimicstack/
     ├── engine.py                     # NEW: Engine Protocol + make_engine factory
     ├── postgres_engine.py            # NEW: existing PG logic, mechanically moved
     ├── duckdb_engine.py              # NEW: in-process duckdb Python package
-    ├── mysql_engine.py               # NEW: PyMySQL or mysql-connector-python
+    ├── mysql_engine.py               # NEW: PyMySQL + LOAD DATA LOCAL INFILE
     ├── sqlite_engine.py              # NEW: stdlib sqlite3 + pandas
-    └── SQL/
-        └── 2.2/
-            ├── postgres/             # MOVED: existing *.sql, unchanged
-            ├── mysql/                # NEW: vendored copy of MIT-LCP load.sql
-            └── (no duckdb/, no sqlite/)   # DDL generated at runtime — see Decision 1
+    └── SQL/2.2/
+        ├── postgres/                 # MOVED: existing *.sql, unchanged
+        └── mysql/                    # NEW: vendored MIT-LCP load.sql (see SHA above)
+                                      # (no duckdb/, no sqlite/ — generated at runtime)
+
+tests/
+├── fixtures/                         # NEW: tiny CSVs per table, ~10 rows each
+└── engines/                          # NEW: smoke test per engine
 ```
 
-### Engine contract
+### Engine contract (lifecycle-explicit)
+
+The Protocol below decomposes the build into distinct lifecycle stages. Each stage is allowed to be a no-op for engines that fold its work into another stage — but the *boundaries* are uniform, which lets the orchestrator be engine-agnostic.
 
 ```python
 # mimicstack/_db/engine.py  (sketch — not yet implemented)
@@ -113,12 +142,40 @@ from typing import Protocol
 
 
 class Engine(Protocol):
+    # ── Connection lifecycle ───────────────────────────────────────────────
     def connect(self) -> None: ...
     def close(self) -> None: ...
-    def data_exists(self, schemas: dict[str, list[str]]) -> bool: ...
-    def apply_ddl(self, schemas: dict[str, list[str]]) -> None: ...   # may be no-op for SQLite
-    def load_table(self, schema: str, table: str, csv_gz_path: Path) -> None: ...
-    def apply_post_load(self) -> None: ...   # PG functions on PG; no-op elsewhere
+
+    # ── Idempotency check ──────────────────────────────────────────────────
+    def data_loaded(self, expected: dict[str, list[str]]) -> bool:
+        """True iff every expected table exists AND contains rows."""
+        ...
+
+    # ── Schema-build lifecycle (each step may be no-op for some engines) ──
+    def prepare_namespaces(self, schemas: list[str]) -> None:
+        """PG: CREATE SCHEMA. MySQL: CREATE DATABASE (currently only `mimic`).
+        DuckDB: CREATE SCHEMA. SQLite: no-op."""
+        ...
+
+    def create_tables(self, schemas: dict[str, list[str]]) -> None:
+        """PG/DuckDB: execute create.sql (transformed for DuckDB).
+        MySQL: execute create+load file (interleaved — see load_dataset).
+        SQLite: no-op (tables built during load_dataset by pandas)."""
+        ...
+
+    # ── Data load (engine chooses internal granularity) ───────────────────
+    def load_dataset(self, schemas: dict[str, list[str]], files: list[Path]) -> None:
+        """Load all CSVs. Engine chooses per-table streaming (PG, DuckDB),
+        per-file chunked-pandas (SQLite), or interleaved create+load
+        (MySQL via LOAD DATA LOCAL INFILE)."""
+        ...
+
+    # ── Post-load (each step may be no-op) ────────────────────────────────
+    def create_indexes(self) -> None: ...
+    def create_constraints(self) -> None: ...
+    def apply_engine_functions(self) -> None:
+        """PG materialised functions only; no-op for the others."""
+        ...
 
 
 def make_engine(config: dict) -> Engine:
@@ -138,142 +195,147 @@ def make_engine(config: dict) -> Engine:
             raise ValueError(f"unknown engine type: {t!r}")
 ```
 
-`MimicImporter` collapses to a ~30-line orchestrator that depends only on `Engine`; no `psycopg2` import survives outside `postgres_engine.py`.
+**`MimicImporter` orchestration** then becomes:
 
-**Note on `apply_ddl()` signature:** changed from `apply_ddl(sql_path: Path)` to `apply_ddl(schemas: dict[str, list[str]])`. This is to accommodate engines that build schema dynamically (SQLite) or have no schema concept at all (MySQL's flat namespace, depending on Decision 3). Each engine decides how to materialise the structured schema info — by reading a SQL file, by transforming one, by introspecting CSVs, or by issuing `CREATE DATABASE` per schema.
+```python
+engine.connect()
+if not engine.data_loaded(expected):
+    engine.prepare_namespaces(list(schemas))
+    engine.create_tables(schemas)
+    engine.load_dataset(schemas, files)
+    engine.create_indexes()
+    engine.create_constraints()
+    engine.apply_engine_functions()
+engine.close()
+```
+
+Every engine implements every stage; some stages are deliberate no-ops. The orchestrator never branches on engine type.
 
 ## Decisions
 
 ### Decision 1 — DDL strategy: per-engine, three different approaches
 
-**Chosen.** A single canonical DDL across all four engines was the original plan, but inspection of MIT-LCP's per-engine artifacts shows the divergence is too large. Each engine uses the artifact that best matches its model:
+**Chosen.** Each engine uses the artifact that best matches its model:
 
-| Engine | DDL source | Lives in |
+| Engine | DDL source | Storage |
 | --- | --- | --- |
-| Postgres | Existing hand-written `create.sql` (canonical for *this project*) | `_db/SQL/2.2/postgres/` |
+| Postgres | Existing hand-written `create.sql` | `_db/SQL/2.2/postgres/` |
 | DuckDB | Postgres DDL + 3 regex transforms at runtime | Generated; no file |
-| MySQL | Vendored copy of MIT-LCP's `mimic-iv/buildmimic/mysql/load.sql` | `_db/SQL/2.2/mysql/` |
-| SQLite | Generated dynamically from CSV columns via `pandas` | Generated; no file |
+| MySQL | Vendored `load.sql` (generated upstream by `csv2mysql`) | `_db/SQL/2.2/mysql/` |
+| SQLite | Built dynamically from CSV columns via `pandas` | Generated; no file |
 
-DuckDB transforms (lifted from MIT-LCP's `mimic-iv/buildmimic/duckdb/import_duckdb.sh`):
+DuckDB transforms (lifted from MIT-LCP's `import_duckdb.sh`):
 
 | # | Pattern | Replacement | Why |
 | --- | --- | --- | --- |
-| 1 | `TIMESTAMP\([0-9]+\)` | `TIMESTAMP` | DuckDB rejects `TIMESTAMP(N)` precision syntax |
-| 2 | `spec_type_desc(.+)NOT NULL` | `spec_type_desc\1` | One zero-length string in source data, treated as NULL by DuckDB import |
+| 1 | `TIMESTAMP\([0-9]+\)` | `TIMESTAMP` | DuckDB rejects `TIMESTAMP(N)` precision |
+| 2 | `spec_type_desc(.+)NOT NULL` | `spec_type_desc\1` | One zero-length string in source data |
 | 3 | `drug +(VARCHAR.+)NOT NULL` | `drug \1` | Multiple zero-length strings in source data |
 
-**Trade-off accepted:** each engine carries the artifact best-suited to its idioms; PRs that update a single engine touch one file. **Risk:** drift between engines when MIMIC schema versions change — each engine's DDL needs an independent update from MIT-LCP upstream. Mitigation: pin the MIT-LCP commit hash in `docs/upstream-sources.md` (future doc) so updates are auditable.
+**Trade-off accepted:** each engine carries the artifact best-suited to its idioms; PRs that update a single engine touch one file. **Risk:** drift between engines when MIMIC schema versions change — mitigated by SHA pinning (see "Upstream source pinning").
 
-**Alternatives considered:**
+**Alternatives considered and rejected:**
 
-- *Single canonical PG DDL + transforms for every engine* — rejected: MySQL diverges too far (type system, namespace, load syntax); SQLite has no use for pre-baked DDL.
-- *SQLGlot transpilation* — rejected for DuckDB (overkill for 3 regexes), unsuitable for MySQL (transpilation doesn't generate `LOAD DATA LOCAL INFILE` clauses), inapplicable for SQLite (dynamic schema).
+- *Single canonical PG DDL + transforms for every engine* — MySQL diverges too far; SQLite has no use for pre-baked DDL.
+- *SQLGlot transpilation* — overkill for DuckDB's 3 regexes; can't generate `LOAD DATA LOCAL INFILE` for MySQL; inapplicable for SQLite.
 
 ### Decision 2 — Config shape: discriminated union by `type`
 
-**Chosen.** Each engine reads only its own block; `make_engine` enforces the shape per type.
+**Chosen.** Each engine reads only its own block; `make_engine` enforces shape per type.
 
 ```jsonc
-// Postgres (existing shape; drop "+asyncpg" suffix — psycopg2 is what we use)
 "database": { "type": "postgresql", "host": "pg", "port": 5432, "database": "postgres", "schema": "public" }
-
-// MySQL (new)
-"database": { "type": "mysql", "host": "mysql", "port": 3306, "database": "mimic" }
-
-// DuckDB (new)
-"database": { "type": "duckdb", "path": "/data/mimic.duckdb" }
-
-// SQLite (new)
-"database": { "type": "sqlite", "path": "/data/mimic4.db" }
+"database": { "type": "mysql",      "host": "mysql", "port": 3306, "database": "mimic" }
+"database": { "type": "duckdb",     "path": "/data/mimic.duckdb" }
+"database": { "type": "sqlite",     "path": "/data/mimic4.db" }
 ```
 
-**Trade-off accepted:** cleanest engine boundary; invalid fields surface immediately at engine construction. **Risk:** small backwards-incompatibility for anyone with a hand-edited `config.json` using `"postgresql+asyncpg"` — a one-character migration; note in CHANGELOG.
+**Trade-off accepted:** cleanest engine boundary; invalid fields surface immediately at construction.
+**Risk:** drop the `"+asyncpg"` suffix in the PG `type` string — note in CHANGELOG; one-character migration for existing users.
 
-**Alternatives considered:**
+### Decision 3 — Namespace model: per-engine; accept MIT-LCP conventions where they diverge
 
-- *Optional fields, engine ignores what it doesn't need* — rejected: hides config errors until runtime.
-- *Nested per-engine blocks* — rejected: most blocks dead at any moment; verbose without benefit.
+**Chosen.** PG and DuckDB keep Postgres-style schemas; MySQL and SQLite use flat tables matching MIT-LCP's upstream conventions.
 
-### Decision 3 — MySQL schema model
-
-MySQL has no `schema` concept in the Postgres sense; it has *databases*. The existing config / DDL assumes `mimic_hosp.admissions`-style schema-qualified names. Three options for MySQL:
-
-| Option | Mapping | Trade-off |
+| Engine | Tables look like | Reason |
 | --- | --- | --- |
-| (a) One DB per schema | `mimic_hosp.admissions` → DB `mimic_hosp`, table `admissions` | Preserves structural grouping; importer must `CREATE DATABASE` per schema and switch contexts (`USE db` or fully-qualified names). Multiple JDBC connections from one client to query across "schemas". |
-| (b) Single DB, prefixed tables | `mimic_hosp.admissions` → `mimic_hosp__admissions` in one DB | One connection from any client. Loses semantic grouping in tooling. |
-| (c) Single DB, flat (MIT-LCP's choice) | `admissions` (no prefix) | Simplest. Loses the hosp/icu/ed/derived separation entirely. |
+| Postgres | `mimic_hosp.admissions` | Existing repo convention |
+| DuckDB | `mimic_hosp.admissions` | DuckDB supports schemas; shares PG DDL |
+| MySQL | `admissions` (no prefix) | MIT-LCP's vendored `load.sql` is namespace-flat; forcing one-DB-per-schema requires forking MIT-LCP DDL |
+| SQLite | `admissions` (no prefix) | SQLite has no schemas; matches MIT-LCP `import.py` |
 
-**Recommendation:** (a) — preserves the structural grouping that exists in every other engine in this stack, in exchange for some importer complexity. The cross-engine consistency is worth more than the per-engine simplicity.
+**Trade-off accepted:** cross-engine queries can't use uniform `schema.table` names. Users querying MIMIC across engines need to know each engine's convention. In exchange, we vendor MIT-LCP's reference implementations unchanged — fewer surprises, easier upstream updates.
 
-**Status:** unconfirmed — needs sign-off before Phase 3b.
+**Earlier draft had this as "one MySQL database per Postgres schema."** That option was rejected on review: it would require maintaining a fork of MIT-LCP's MySQL DDL (splitting one `load.sql` into N per-schema files), it doesn't fix SQLite's flat-namespace constraint, and the user-visible benefit (uniform names in tooling) is achievable post-hoc via view-only schema mappings if demand surfaces.
+
+**Status:** confirmed (this revision).
 
 ### Bulk-load mechanics per engine
 
-| Engine | Mechanism | Notes |
+| Engine | Mechanism | Internal granularity |
 | --- | --- | --- |
-| Postgres | `\copy ... FROM PROGRAM 'gzip -dc ...'` via shelled-out `psql` | Unchanged from today |
-| MySQL | `LOAD DATA LOCAL INFILE '...' INTO TABLE ... FIELDS TERMINATED BY ',' ...` | Requires `local_infile=1` server-side and on client; per-column `trim()` / NULL handling per MIT-LCP `load.sql` |
-| DuckDB | `COPY {schema}.{table} FROM '{path}' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"', COMPRESSION 'gzip')` | DuckDB reads `.csv.gz` natively, no decompression pipe |
-| SQLite | `pandas.read_csv(...)` then `df.to_sql(table, conn, chunksize=10**6)` | Per MIT-LCP `import.py`; chunked for memory; dynamic schema inferred from CSV |
+| Postgres | `\copy ... FROM PROGRAM 'gzip -dc ...'` via shelled-out `psql` | Per table |
+| MySQL | `LOAD DATA LOCAL INFILE '...' INTO TABLE ... FIELDS TERMINATED BY ',' ...` (requires `local_infile=1`) | Interleaved with table creation in vendored `load.sql` |
+| DuckDB | `COPY {schema}.{table} FROM '{path}' (HEADER, DELIM ',', QUOTE '"', ESCAPE '"', COMPRESSION 'gzip')` | Per table |
+| SQLite | `pandas.read_csv(..., chunksize=10**6)` → `df.to_sql(table, conn)` | Per file (chunked) |
 
-## Open questions
+The Engine Protocol's `load_dataset(schemas, files)` hides this granularity from the orchestrator.
 
-### Schema naming alignment (cross-engine)
+## Failure semantics and partial-load policy
 
-MIT-LCP's DuckDB script writes to `mimiciv_hosp` / `mimiciv_icu`. MIT-LCP's MySQL `load.sql` uses no schemas at all (option (c) above). This repo's Postgres side uses `mimic_hosp` / `mimic_icu`.
+Each engine must declare a failure mode and a recovery mode. Codified explicitly so the importer doesn't leave half-built artifacts that the next run silently treats as "data already loaded."
 
-**Recommendation:** keep this repo's existing `mimic_hosp` / `mimic_icu` everywhere. Users coming from MIT-LCP's DuckDB notebooks or MySQL examples will need to rename schemas / tables in queries — accepted one-time cost for internal consistency across the four engines this project ships.
+| Engine | Failure mode | Recovery |
+| --- | --- | --- |
+| Postgres | DDL is transactional; bulk-load is not (per-table commits). Partial load → some tables full, others empty. | `data_loaded()` checks row counts per expected table; partial state forces a full re-run (drop + recreate). |
+| MySQL | DDL is **implicitly auto-committed**. Partial load can leave half the DB created. | Same: row-count check; partial state forces drop + recreate. Document privilege requirement (`DROP`, `CREATE`, `FILE` for `LOAD DATA LOCAL INFILE`). |
+| DuckDB | Single-process writer; crash mid-build leaves a truncated file. | Build into `{path}.tmp`; `os.rename({path}.tmp, {path})` only after `create_indexes`/`create_constraints` succeed. Atomic on POSIX. |
+| SQLite | Same as DuckDB (single file). | Same `.tmp` + atomic rename strategy. |
 
-**Status:** unconfirmed — sign off in conjunction with Decision 3.
+`data_loaded()` is the integrity gate: it returns True only if **every** expected table is present **and** non-empty. Today's `_check_data()` (`_db_handler.py:27-55`) checks only existence — we are explicitly tightening this contract.
 
-### Pandas dependency for SQLite
+## Test strategy (must land with Phase 1)
 
-`SQLiteEngine` needs `pandas` if we follow MIT-LCP's `import.py` approach. Pandas is a heavy dependency (numpy transitively). Alternatives:
+A test matrix is non-negotiable before any engine-specific code lands. Codex review flagged this; the plan is:
 
-- *Stream CSV with stdlib `csv` + `executemany`* — much smaller dep footprint; more code to write; we re-invent MIT-LCP's logic.
-- *Accept pandas as a SQLite-only dependency* — `pixi.toml` can scope the dep to the `sqlite-builder` feature so the Postgres importer image stays slim.
-
-**Recommendation:** scope pandas to the SQLite builder via pixi features; don't make every install pay for it.
-
-**Status:** unconfirmed.
+- `tests/fixtures/2.2/` — tiny CSV files (~10 rows per table) covering at least one table from each schema (`mimic_hosp`, `mimic_icu`, `mimiciv_ed`). Include at least one row exercising the NULL/zero-length-string corner case that drives DuckDB's two `NOT NULL` regex transforms.
+- `tests/engines/test_<engine>_smoke.py` — one per engine: build from fixtures, assert table counts, assert representative row, assert one cross-table JOIN works (validates relational integrity).
+- `tests/engines/test_parity.py` — same query against all four engines, identical results modulo namespace prefix.
+- CI runs the smoke matrix on every PR; parity test runs on `feat/expand-platform` branch PRs.
 
 ## Image / packaging changes
-
-Today: one `mimic_import.dockerfile` installs `postgresql-client`.
-
-Target — one builder/importer image per engine, scoped via pixi features:
 
 | Image | Base | Engine deps | Output |
 | --- | --- | --- | --- |
 | `images/postgres-importer.dockerfile` | python-slim | `psycopg2`, `postgresql-client` (binary) | Loads into running PG container |
-| `images/mysql-importer.dockerfile` | python-slim | `PyMySQL` or `mysql-connector-python`, `mysql-client` (for `LOAD DATA LOCAL INFILE`) | Loads into running MySQL container |
+| `images/mysql-importer.dockerfile` | python-slim | `PyMySQL`, `mysql-client` (for `LOAD DATA LOCAL INFILE`) | Loads into running MySQL container |
 | `images/duckdb-builder.dockerfile` | python-slim | `duckdb` (pip) | `mimic.duckdb` on mounted volume |
 | `images/sqlite-builder.dockerfile` | python-slim | `pandas`, `sqlite3` (stdlib) | `mimic4.db` on mounted volume |
 
-`docker-compose.yaml` grows compose profiles per engine (e.g. `docker compose --profile duckdb up`); decide concrete shape during Phase 4.
+Pandas is scoped to the SQLite builder feature in `pixi.toml`; other images don't pay for it.
+
+`docker-compose.yaml` grows compose profiles per engine — concrete shape decided during Phase 4.
 
 ## Implementation phases
-
-Each phase is a reviewable PR. Later phases assume earlier ones are merged.
 
 | Phase | Scope | Risk |
 | --- | --- | --- |
 | 0 | This plan doc | None |
-| 1 | Module rename `pgmimic/` → `mimicstack/`; no behaviour change | Low — pure rename + import-path fixups |
-| 2 | Scaffold `Engine` Protocol + `make_engine`; move existing PG logic into `PostgresEngine` behind the new interface | Medium — refactor of working code, needs end-to-end smoke test |
-| 3a | Add `DuckDBEngine` with three regex DDL transforms + native `csv.gz` load | Medium — new dep, new code path |
-| 3b | Add `MySQLEngine`: vendor MIT-LCP `load.sql`, `LOAD DATA LOCAL INFILE`, MySQL container in compose | Medium-high — schema model decision, MySQL-specific load quirks (`local_infile`) |
-| 3c | Add `SQLiteEngine`: port MIT-LCP `import.py` approach (pandas chunked load + dynamic schema) | Medium — new dep (pandas), scoped via pixi |
-| 4 | Per-engine Dockerfiles + compose profiles | Low — packaging |
-| 5 | README rewrite; rename GitHub repository to `MimicDataStack` | Low — coordination only |
+| 1 | In-tree rename `pgmimic/` → `mimicstack/`; **add test fixtures and Postgres smoke test** (validates the renamed structure works end-to-end) | Low — pure rename + first tests |
+| 2 | Scaffold `Engine` Protocol with the lifecycle-explicit shape; move existing PG logic into `PostgresEngine`; tighten `data_loaded()` to check row counts; add partial-load recovery for PG | Medium — refactor, but covered by Phase 1 smoke tests |
+| 3a | Add `DuckDBEngine`: regex DDL transforms, native csv.gz load, `.tmp` + atomic rename | Medium — first non-PG engine; will reveal Protocol gaps if any |
+| 3b | Add `MySQLEngine`: vendor MIT-LCP `load.sql` (flat namespace), `LOAD DATA LOCAL INFILE`, MySQL container in compose, document `local_infile=1` and required GRANTs | Medium-high — `LOAD DATA LOCAL INFILE` privilege footgun |
+| 3c | Add `SQLiteEngine`: port MIT-LCP `import.py` (pandas chunked load + dynamic schema), `.tmp` + atomic rename, scope pandas via pixi feature | Medium — new dep (pandas) |
+| 4 | Per-engine Dockerfiles + compose profiles | Low |
+| 5 | **Conditional rebrand:** if Phases 3a–3c all shipped successfully, rename GitHub repo to `MimicDataStack`, rewrite README. **If 3a uncovered fundamental abstraction problems, do not rebrand** — the rebrand commits us publicly to a multi-engine story; we shouldn't commit until the story works. | Low (coordination) or N/A (abort) |
 
-Phases 3a / 3b / 3c can in principle proceed in parallel after Phase 2 lands, but reviewing them serially is recommended to catch Engine-contract issues that surface only when the second or third implementation reveals an unworkable abstraction.
+Phase 1 is the gate that protects everything downstream. If you skip the test fixtures here, every later phase reviews itself blind.
 
 ## Future work (deliberately deferred)
 
+- **Per-DB MySQL schemas** — unify the cross-engine namespace model by mapping each Postgres schema to a separate MySQL database. Requires forking MIT-LCP's `load.sql` into per-schema chunks and accepting the resulting maintenance burden. Worth it only if real users hit the inconsistency.
+- **View-based schema mapping for MySQL/SQLite** — create views like `mimic_hosp.admissions` over the flat tables. Cheap; could land as a Phase 6 polish if demand exists.
 - **Spark engine** slotting into the same `Engine` Protocol: `{"type": "spark", "master": "spark://...", "warehouse": "s3://..."}`. The `match` statement in `make_engine` is the extension point.
-- **BigQuery engine** — MIT-LCP supports it (`mimic-iv/buildmimic/bigquery/`); cloud-only, deferred until cloud-account onboarding story is solved.
-- **k3s deployment** — Helm chart for the Postgres and MySQL paths. The file-mode engines (DuckDB, SQLite) won't benefit (in-process file producers; nothing to orchestrate).
-- **DuckDB server-mode** — revisit if/when DuckDB ships a stable wire protocol that JDBC clients can speak directly.
+- **BigQuery engine** — MIT-LCP supports it; cloud-only, deferred until cloud-account onboarding story exists.
+- **k3s deployment** — Helm chart for PG and MySQL paths. File-mode engines won't benefit.
+- **DuckDB server-mode** — revisit if/when DuckDB ships a stable wire protocol JDBC clients can speak directly.


### PR DESCRIPTION
## Summary

- Adds `docs/platform-plan.md` capturing the plan to extend this project from Postgres-only to a multi-engine MIMIC data stack, starting with DuckDB.
- Locks two architectural decisions: **canonical Postgres DDL + regex transforms** for DuckDB (lifted from MIT-LCP's `import_duckdb.sh`) and **discriminated-union `config.json`** keyed on `database.type`.
- Flags one open question: schema-naming alignment (`mimic_hosp` vs MIT-LCP's `mimiciv_hosp`).
- Proposes renaming `pgmimic/` → `mimicstack/` and the repo to `MimicDataStack` once the in-tree work lands.

Draft / WIP — this PR is the plan only. No code changes; follow-up PRs implement the phases.

## Test plan

- [ ] Review `docs/platform-plan.md` for accuracy of the current-state description (file paths, line refs in `pgmimic/_db/_db_handler.py`).
- [ ] Confirm or revise the schema-naming recommendation (Open Questions section).
- [ ] Sign off on the phased rollout (Phases 1–5) before any implementation PR opens.