### PR TITLE
Add devcontainer + direnv (pixi) support

### DIFF
--- a/.changes/unreleased/Added-20260518-205852.yaml
+++ b/.changes/unreleased/Added-20260518-205852.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: '`.devcontainer/` (compose-based, Postgres 14 alongside) and committed `.envrc` (`pixi shell-hook --environment dev` via direnv) for one-command IDE / Codespaces / direnv onboarding. `.gitignore` covers `.direnv/`, `.envrc.local`, `.worktrees/`, and `.devcontainer/.env`.'
+time: 2026-05-18T20:58:52+10:00

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,5 +4,5 @@ FROM ghcr.io/prefix-dev/pixi:0.67.2
 # pixi env, but we also need the psql/gzip client binaries for the import path.
 # git is added for the VS Code source-control integration.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client git && \
+    apt-get install -y --no-install-recommends postgresql-client gzip git && \
     rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM ghcr.io/prefix-dev/pixi:0.67.2
+
+# psql is shelled out by _db_handler; libpq comes via conda-forge psycopg2 in the
+# pixi env, but we also need the psql/gzip client binaries for the import path.
+# git is added for the VS Code source-control integration.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-client git && \
+    rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "service": "app",
   "workspaceFolder": "/workspace",
   "shutdownAction": "stopCompose",
-  "postCreateCommand": "pixi install -e dev",
+  "postCreateCommand": "pixi install -e dev --locked",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "pgmimic-dev",
+  "dockerComposeFile": "docker-compose.yaml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "shutdownAction": "stopCompose",
+  "postCreateCommand": "pixi install -e dev",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "ms-azuretools.vscode-docker",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -16,11 +16,11 @@ services:
         condition: service_healthy
 
   pg:
-    image: postgres:14.0-alpine
+    image: postgres:14-alpine
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-dev}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-dev}
-      - POSTGRES_DB=${POSTGRES_DB:-mimiciv}
+      - POSTGRES_DB=${POSTGRES_DB:-postgres}
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER:-dev}"]
       interval: 10s

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,33 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: sleep infinity
+    working_dir: /workspace
+    volumes:
+      - ..:/workspace:cached
+    environment:
+      - DB_USER=${POSTGRES_USER:-dev}
+      - DB_PASSWORD=${POSTGRES_PASSWORD:-dev}
+      - PYTHONUNBUFFERED=1
+    depends_on:
+      pg:
+        condition: service_healthy
+
+  pg:
+    image: postgres:14.0-alpine
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER:-dev}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-dev}
+      - POSTGRES_DB=${POSTGRES_DB:-mimiciv}
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER:-dev}"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+    volumes:
+      - pgmimic-devcontainer-db:/var/lib/postgresql/data/
+
+volumes:
+  pgmimic-devcontainer-db:

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+# Auto-activate the pixi `dev` environment when entering this directory.
+# Requires direnv (https://direnv.net) and pixi (https://pixi.sh).
+# Run `direnv allow` once after cloning to opt in.
+#
+# Docs: https://pixi.prefix.dev/v0.47.0/integration/third_party/direnv/
+
+watch_file pyproject.toml pixi.lock
+eval "$(pixi shell-hook --environment dev)"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,13 @@ __pycache__
 ## pixi environments ##
 .pixi/*
 !.pixi/config.toml
+
+## direnv ##
+.direnv/
+.envrc.local
+
+## worktrees ##
+.worktrees/
+
+## devcontainer local overrides ##
+.devcontainer/.env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,13 @@ Thank you for your interest in our little project. I appreciate any support to h
 3. Make your changes in the new branch.
 4. Submit a [pull request (PR)](https://github.com/rudolfjs/PostgresMimicImporter/pull/new/master) to the main repository.
 
+## Development environment
+
+Pick whichever fits your setup — both run the same `pixi` tasks:
+
+- **Devcontainer** — open the repo in VS Code, JetBrains Gateway, or GitHub Codespaces and choose *Reopen in Container*. The config in `.devcontainer/` builds a pixi-based image with `postgresql-client` and brings up Postgres 14 alongside, so the `dev` pixi env is ready and the importer can run end-to-end without any local Python or DB install.
+- **Local pixi (+ direnv)** — install [pixi](https://pixi.sh); the committed `.envrc` auto-activates the `dev` env if you also use [direnv](https://direnv.net) (run `direnv allow` once after cloning). Without direnv, prefix dev commands with `pixi run -e dev`.
+
 ## Pull Request Guidelines
 
 When [submitting a pull request](https://github.com/rudolfjs/PostgresMimicImporter/pull/new/master) please ensure that:


### PR DESCRIPTION
## Summary

- New `.devcontainer/` (compose-based): an `app` service built from `ghcr.io/prefix-dev/pixi:0.67.2` with `postgresql-client` + `git`, plus a `pg` Postgres 14 service alongside. `postCreateCommand: pixi install -e dev` provisions the dev environment on first start so `Reopen in Container` / Codespaces gives a contributor a complete, working dev setup with zero local Python or DB install.
- New committed `.envrc` using `pixi shell-hook --environment dev` (per the [pixi direnv docs](https://pixi.prefix.dev/v0.47.0/integration/third_party/direnv/)) so contributors who already use [direnv](https://direnv.net) get the `dev` pixi env auto-activated on `cd`. Opt-in per clone (`direnv allow`).
- `.gitignore`: ignore `.direnv/`, `.envrc.local`, `.worktrees/`, and `.devcontainer/.env`.
- `CONTRIBUTING.md`: new "Development environment" section documenting both paths (devcontainer vs local pixi + direnv).
- Changie entry under "Added".

The compose file uses `${POSTGRES_USER:-dev}` / `${POSTGRES_PASSWORD:-dev}` / `${POSTGRES_DB:-postgres}` defaults so the devcontainer works without a pre-existing `.env`. Contributors who already have `.env` keep their existing values.

This was triggered after reviewing #7 (closed obsolete) — see also follow-up issue #9 for the still-open exception-swallow work in `ConfigHandler.__init__`.

## Test plan

- [ ] `docker compose -f .devcontainer/docker-compose.yaml config` parses cleanly (verified locally with `podman-compose config`)
- [ ] `python3 -c \"import json; json.load(open('.devcontainer/devcontainer.json'))\"` succeeds (verified)
- [ ] Open the repo in VS Code → *Reopen in Container* → `pixi run -e dev lint`, `pixi run -e dev test`, `pixi run -e dev typecheck` all pass inside the container
- [ ] On a host with `direnv` + `pixi` installed: `direnv allow` activates the `dev` env on `cd` (check `which python` resolves under `.pixi/envs/dev/bin/`)
- [ ] Codespaces smoke test: launch a Codespace from this branch and confirm `postCreateCommand` completes and the `pg` service becomes healthy
- [ ] Confirm existing `docker compose up` (root compose file) is unaffected — the devcontainer compose is independent

## Notes for reviewer

- Postgres data persists in the named volume `pgmimic-devcontainer-db` (separate from prod's `db-data`), so the devcontainer stack can be torn down + reset without touching any prod-style local state.
- No changes to runtime code, dockerfile, or root `docker-compose.yaml`.
